### PR TITLE
Compute chunk size from audio format

### DIFF
--- a/ESCA/src/modules/aiprocess/sharedmemorymanager.h
+++ b/ESCA/src/modules/aiprocess/sharedmemorymanager.h
@@ -25,6 +25,7 @@ protected:
 public slots:
     void getAudioData(const QByteArray &data);
     void stop();
+    void setBufferSize(size_t size) { shm_size = size; }
 
 signals:
     void bufferChanged();

--- a/ESCA/src/modules/audiorecording/recordingcontroller.cpp
+++ b/ESCA/src/modules/audiorecording/recordingcontroller.cpp
@@ -12,6 +12,7 @@ RecordingController::RecordingController(QObject *parent)
     , m_format(m_audioConfig->format())
     , m_recStatus(false)
     , sharedMemoryManager(new SharedMemoryManager(this))
+    , m_chunkSize(calculateChunkSize(m_format, 2.0))
 {
     qmlRegisterSingletonInstance("AudioChartImport", 1, 0, "AudioChart", m_recordingChart);
     qmlRegisterSingletonInstance("AudioConfigImport", 1, 0, "AudioConfig", m_audioConfig);
@@ -22,6 +23,7 @@ RecordingController::RecordingController(QObject *parent)
     connect(this, &RecordingController::sendChartData, m_recordingChart, &RecordingChart::onSendChartData);
 
     qInfo()<<"format in ini: "<<m_audioConfig->format();
+    sharedMemoryManager->setBufferSize(m_chunkSize);
 
     if (!sharedMemoryManager->init_ipc()) {
         qDebug() << "Failed to initialize IPC.";
@@ -56,6 +58,8 @@ void RecordingController::startRecording()
 {
     connect(m_recordIO, &RecordIO::sendData, this, &RecordingController::handleDataReady);
     m_format = m_audioConfig->format();
+    m_chunkSize = calculateChunkSize(m_format, 2.0);
+    sharedMemoryManager->setBufferSize(m_chunkSize);
     qDebug()<< "format"<< m_format;
 
     QAudioDeviceInfo deviceInfo = m_audioConfig->deviceInfo();
@@ -108,6 +112,9 @@ void RecordingController::startSharedMemory(){
     connect(m_recordIO, &RecordIO::sendData, this, &RecordingController::handleSharedMemory);
 
     QAudioDeviceInfo deviceInfo = m_audioConfig->deviceInfo();
+    m_format = m_audioConfig->format();
+    m_chunkSize = calculateChunkSize(m_format, 2.0);
+    sharedMemoryManager->setBufferSize(m_chunkSize);
     sharedMemoryManager->start();
     m_recordIO->startAudioInput(m_format, deviceInfo);
     qInfo() << "format before shm" << m_format;
@@ -123,65 +130,32 @@ void RecordingController::stopSharedMemory()
 void RecordingController::handleDataReady(const QByteArray &data)
 {
     QString duration = m_audioConfig->duration();
-    // static QDateTime lastSwapTime = QDateTime::currentDateTime();
-    QByteArray &activeBuffer = m_usingBuffer1 ? audioBuffer1 : audioBuffer2;
-
-    activeBuffer.append(data);
-
-    // Log kích thước buffer và thời gian
-    // qDebug() << "handleDataReady() at" << QDateTime::currentDateTime().toString("hh:mm:ss.zzz")
-    //          << "buffer size:" << activeBuffer.size();
-
-    if (activeBuffer.size() >= 176400) {
-        QByteArray dataToSend = activeBuffer.left(176400);
-        activeBuffer.remove(0, 176400);
-
-        // Swap buffer
-        m_usingBuffer1 = !m_usingBuffer1;
-        // lastSwapTime = swapStartTime;
-
-        // qDebug() << "Real-time data - First 10 bytes: " << dataToSend.mid(0, 10);
-        // QDateTime swapStartTime = QDateTime::currentDateTime();
-        // qDebug() << "🔄 Buffer Swap! Ready to send shared memory at:" << swapStartTime.toString("hh:mm:ss.zzz");
-
-        // sharedMemoryManager->getAudioData(dataToSend);
-        // qDebug() << "✅ Writing to shared memory completed at:" << QDateTime::currentDateTime().toString("hh:mm:ss.zzz");
-
-        if (duration == "2s"){
-            // Chuyển tiếp dữ liệu cho AudioFile để xử lý buffering và ghi file
+    processBuffer(data, [this, &duration](const QByteArray &chunk){
+        if (duration == "2s") {
             if (m_audioFile) {
                 QMetaObject::invokeMethod(m_audioFile, "writeAudioData",
                                           Qt::QueuedConnection,
-                                          Q_ARG(QByteArray, dataToSend));
+                                          Q_ARG(QByteArray, chunk));
             }
-        }
-        else {
+        } else {
             if (m_audioFile) {
                 QMetaObject::invokeMethod(m_audioFile, "writeDataForever",
                                           Qt::QueuedConnection,
-                                          Q_ARG(QByteArray, dataToSend));
+                                          Q_ARG(QByteArray, chunk));
             }
         }
-    }
+    });
 
     m_recordingChart->onSendChartData(data);
 }
 
 void RecordingController::handleSharedMemory(const QByteArray &data) {
-    QString duration = m_audioConfig->duration();
-    // static QDateTime lastSwapTime = QDateTime::currentDateTime();
-    QByteArray &activeBuffer = m_usingBuffer1 ? audioBuffer1 : audioBuffer2;
-
-    activeBuffer.append(data);
-
-    if (activeBuffer.size() >= 176400) {
-        QByteArray dataToSend = activeBuffer.left(176400);
-        activeBuffer.remove(0, 176400);
-        qDebug() << "Real-time SharedMemory - First 10 bytes: " << dataToSend.mid(0, 30);
-        m_usingBuffer1 = !m_usingBuffer1;
-        sharedMemoryManager->getAudioData(dataToSend);
-    }
+    processBuffer(data, [this](const QByteArray &chunk){
+        qDebug() << "Real-time SharedMemory - First 10 bytes: " << chunk.mid(0, 30);
+        sharedMemoryManager->getAudioData(chunk);
+    });
 }
+
 
 bool RecordingController::recStatus() /*const*/
 {
@@ -194,4 +168,24 @@ void RecordingController::setRecStatus(bool newRecStatus)
         return;
     m_recStatus = newRecStatus;
     emit recStatusChanged();
+}
+
+size_t RecordingController::calculateChunkSize(const QAudioFormat &format, double durationSec)
+{
+    return static_cast<size_t>(format.sampleRate() * (format.sampleSize() / 8) *
+                              format.channelCount() * durationSec);
+}
+
+void RecordingController::processBuffer(const QByteArray &data,
+                                        const std::function<void(const QByteArray&)> &onChunkReady)
+{
+    QByteArray &activeBuffer = m_usingBuffer1 ? audioBuffer1 : audioBuffer2;
+    activeBuffer.append(data);
+
+    if (activeBuffer.size() >= static_cast<int>(m_chunkSize)) {
+        QByteArray chunk = activeBuffer.left(m_chunkSize);
+        activeBuffer.remove(0, m_chunkSize);
+        m_usingBuffer1 = !m_usingBuffer1;
+        onChunkReady(chunk);
+    }
 }

--- a/ESCA/src/modules/audiorecording/recordingcontroller.h
+++ b/ESCA/src/modules/audiorecording/recordingcontroller.h
@@ -8,6 +8,7 @@
 #include <QQmlEngine>
 #include <QThread>
 #include <QMutex>
+#include <functional>
 
 #include "../../config/config.h"
 
@@ -60,7 +61,10 @@ private:
     QByteArray audioBuffer2;
     bool m_usingBuffer1;
 
-    const size_t chunkSize = 176400;
+    size_t m_chunkSize;
+    size_t calculateChunkSize(const QAudioFormat &format, double durationSec);
+    void processBuffer(const QByteArray &data,
+                       const std::function<void(const QByteArray&)> &onChunkReady);
     
     bool m_recStatus;
 };


### PR DESCRIPTION
## Summary
- calculate recording chunk size from QAudioFormat
- refactor buffer handling logic
- allow SharedMemoryManager to accept buffer size

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`